### PR TITLE
Change the base url to `https://api.openai.com/v1` instead of `https://api.openai.com`

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ OpenAiService is versatile in its setup options, as demonstrated in the `example
 example package.
 
 ```java
-//1. Use the default baseUrl, automatically configured service; initially fetches BaseURL from environment variable (key: OPENAI_API_BASE_URL), defaults to "https://api.openai.com/v1" if not found.
+//1. Use the default baseUrl, automatically configured service; initially fetches BaseURL from environment variable (key: OPENAI_API_BASE_URL), defaults to "https://api.openai.com/v1/" if not found.
 OpenAiService openAiService = new OpenAiService(API_KEY);
 //2. Use a custom baseUrl with the standard configuration
 OpenAiService openAiService1 = new OpenAiService(API_KEY, BASE_URL);

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ OpenAiService is versatile in its setup options, as demonstrated in the `example
 example package.
 
 ```java
-//1. Use the default baseUrl, automatically configured service; initially fetches BaseURL from environment variable (key: OPENAI_API_BASE_URL), defaults to "https://api.openai.com/" if not found.
+//1. Use the default baseUrl, automatically configured service; initially fetches BaseURL from environment variable (key: OPENAI_API_BASE_URL), defaults to "https://api.openai.com/v1" if not found.
 OpenAiService openAiService = new OpenAiService(API_KEY);
 //2. Use a custom baseUrl with the standard configuration
 OpenAiService openAiService1 = new OpenAiService(API_KEY, BASE_URL);

--- a/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
+++ b/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
@@ -50,92 +50,92 @@ import java.util.Map;
 
 public interface OpenAiApi {
 
-    @GET("/models")
+    @GET("models")
     Single<OpenAiResponse<Model>> listModels();
 
-    @GET("/models/{model_id}")
+    @GET("models/{model_id}")
     Single<Model> getModel(@Path("model_id") String modelId);
 
-    @POST("/completions")
+    @POST("completions")
     Single<CompletionResult> createCompletion(@Body CompletionRequest request);
 
     @Streaming
-    @POST("/completions")
+    @POST("completions")
     Call<ResponseBody> createCompletionStream(@Body CompletionRequest request);
 
-    @POST("/chat/completions")
+    @POST("chat/completions")
     Single<ChatCompletionResult> createChatCompletion(@Body ChatCompletionRequest request);
 
     @Streaming
-    @POST("/chat/completions")
+    @POST("chat/completions")
     Call<ResponseBody> createChatCompletionStream(@Body ChatCompletionRequest request);
 
 
-    @POST("/edits")
+    @POST("edits")
     Single<EditResult> createEdit(@Body EditRequest request);
 
 
-    @POST("/embeddings")
+    @POST("embeddings")
     Single<EmbeddingResult> createEmbeddings(@Body EmbeddingRequest request);
 
 
-    @GET("/files")
+    @GET("files")
     Single<OpenAiResponse<File>> listFiles();
 
     @Multipart
-    @POST("/files")
+    @POST("files")
     Single<File> uploadFile(@Part("purpose") RequestBody purpose, @Part MultipartBody.Part file);
 
-    @DELETE("/files/{file_id}")
+    @DELETE("files/{file_id}")
     Single<DeleteResult> deleteFile(@Path("file_id") String fileId);
 
-    @GET("/files/{file_id}")
+    @GET("files/{file_id}")
     Single<File> retrieveFile(@Path("file_id") String fileId);
 
     @Streaming
-    @GET("/files/{file_id}/content")
+    @GET("files/{file_id}/content")
     Single<ResponseBody> retrieveFileContent(@Path("file_id") String fileId);
 
-    @POST("/fine_tuning/jobs")
+    @POST("fine_tuning/jobs")
     Single<FineTuningJob> createFineTuningJob(@Body FineTuningJobRequest request);
 
-    @GET("/fine_tuning/jobs")
+    @GET("fine_tuning/jobs")
     Single<OpenAiResponse<FineTuningJob>> listFineTuningJobs();
 
-    @GET("/fine_tuning/jobs/{fine_tuning_job_id}")
+    @GET("fine_tuning/jobs/{fine_tuning_job_id}")
     Single<FineTuningJob> retrieveFineTuningJob(@Path("fine_tuning_job_id") String fineTuningJobId);
 
-    @POST("/fine_tuning/jobs/{fine_tuning_job_id}/cancel")
+    @POST("fine_tuning/jobs/{fine_tuning_job_id}/cancel")
     Single<FineTuningJob> cancelFineTuningJob(@Path("fine_tuning_job_id") String fineTuningJobId);
 
-    @GET("/fine_tuning/jobs/{fine_tuning_job_id}/events")
+    @GET("fine_tuning/jobs/{fine_tuning_job_id}/events")
     Single<OpenAiResponse<FineTuningEvent>> listFineTuningJobEvents(@Path("fine_tuning_job_id") String fineTuningJobId);
 
-    @POST("/completions")
+    @POST("completions")
     Single<CompletionResult> createFineTuneCompletion(@Body CompletionRequest request);
 
-    @DELETE("/models/{fine_tune_id}")
+    @DELETE("models/{fine_tune_id}")
     Single<DeleteResult> deleteFineTune(@Path("fine_tune_id") String fineTuneId);
 
-    @POST("/images/generations")
+    @POST("images/generations")
     Single<ImageResult> createImage(@Body CreateImageRequest request);
 
-    @POST("/images/edits")
+    @POST("images/edits")
     Single<ImageResult> createImageEdit(@Body RequestBody requestBody);
 
-    @POST("/images/variations")
+    @POST("images/variations")
     Single<ImageResult> createImageVariation(@Body RequestBody requestBody);
 
-    @POST("/audio/transcriptions")
+    @POST("audio/transcriptions")
     Single<TranscriptionResult> createTranscription(@Body RequestBody requestBody);
 
-    @POST("/audio/translations")
+    @POST("audio/translations")
     Single<TranslationResult> createTranslation(@Body RequestBody requestBody);
 
-    @POST("/audio/speech")
+    @POST("audio/speech")
     Single<ResponseBody> createSpeech(@Body CreateSpeechRequest requestBody);
 
-    @POST("/moderations")
+    @POST("moderations")
     Single<ModerationResult> createModeration(@Body ModerationRequest request);
 
     /**
@@ -144,7 +144,7 @@ public interface OpenAiApi {
      * @return
      */
     @Deprecated
-    @GET("/dashboard/billing/subscription")
+    @GET("dashboard/billing/subscription")
     Single<Subscription> subscription();
 
     /**
@@ -156,182 +156,185 @@ public interface OpenAiApi {
      * @return Consumption amount information.
      */
     @Deprecated
-    @GET("/dashboard/billing/usage")
+    @GET("dashboard/billing/usage")
     Single<BillingUsage> billingUsage(@Query("start_date") LocalDate starDate, @Query("end_date") LocalDate endDate);
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/assistants")
+    @POST("assistants")
     Single<Assistant> createAssistant(@Body AssistantRequest request);
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/assistants")
+    @GET("assistants")
     Single<OpenAiResponse<Assistant>> listAssistants(@QueryMap Map<String, Object> filterRequest);
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/assistants/{assistant_id}")
+    @GET("assistants/{assistant_id}")
     Single<Assistant> retrieveAssistant(@Path("assistant_id") String assistantId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/assistants/{assistant_id}")
+    @POST("assistants/{assistant_id}")
     Single<Assistant> modifyAssistant(@Path("assistant_id") String assistantId, @Body ModifyAssistantRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @DELETE("/assistants/{assistant_id}")
+    @DELETE("assistants/{assistant_id}")
     Single<DeleteResult> deleteAssistant(@Path("assistant_id") String assistantId);
 
     //----
 
+    @Headers({"OpenAI-Beta: assistants=v1"})
+    @POST("assistants/{assistant_id}/files")
+    Single<AssistantFile> createAssistantFile(@Path("assistant_id") String assistantId, @Body AssistantFileRequest fileRequest);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/assistants/{assistant_id}/files/{file_id}")
+    @GET("assistants/{assistant_id}/files/{file_id}")
     Single<AssistantFile> retrieveAssistantFile(@Path("assistant_id") String assistantId, @Path("file_id") String fileId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @DELETE("/assistants/{assistant_id}/files/{file_id}")
+    @DELETE("assistants/{assistant_id}/files/{file_id}")
     Single<DeleteResult> deleteAssistantFile(@Path("assistant_id") String assistantId, @Path("file_id") String fileId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/assistants/{assistant_id}/files")
+    @GET("assistants/{assistant_id}/files")
     Single<OpenAiResponse<AssistantFile>> listAssistantFiles(@Path("assistant_id") String assistantId, @QueryMap Map<String, Object> filterRequest);
 
     //---
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/threads")
+    @POST("threads")
     Single<Thread> createThread(@Body ThreadRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/threads/{thread_id}")
+    @GET("threads/{thread_id}")
     Single<Thread> retrieveThread(@Path("thread_id") String threadId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/threads/{thread_id}")
+    @POST("threads/{thread_id}")
     Single<Thread> modifyThread(@Path("thread_id") String threadId, @Body ThreadRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @DELETE("/threads/{thread_id}")
+    @DELETE("threads/{thread_id}")
     Single<DeleteResult> deleteThread(@Path("thread_id") String threadId);
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/threads/{thread_id}/messages")
+    @POST("threads/{thread_id}/messages")
     Single<Message> createMessage(@Path("thread_id") String threadId, @Body MessageRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/threads/{thread_id}/messages/{message_id}")
+    @GET("threads/{thread_id}/messages/{message_id}")
     Single<Message> retrieveMessage(@Path("thread_id") String threadId, @Path("message_id") String messageId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/threads/{thread_id}/messages/{message_id}")
+    @POST("threads/{thread_id}/messages/{message_id}")
     Single<Message> modifyMessage(@Path("thread_id") String threadId, @Path("message_id") String messageId, @Body ModifyMessageRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/threads/{thread_id}/messages")
+    @GET("threads/{thread_id}/messages")
     Single<OpenAiResponse<Message>> listMessages(@Path("thread_id") String threadId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/threads/{thread_id}/messages")
+    @GET("threads/{thread_id}/messages")
     Single<OpenAiResponse<Message>> listMessages(@Path("thread_id") String threadId, @QueryMap Map<String, Object> filterRequest);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/threads/{thread_id}/messages/{message_id}/files/{file_id}")
+    @GET("threads/{thread_id}/messages/{message_id}/files/{file_id}")
     Single<MessageFile> retrieveMessageFile(@Path("thread_id") String threadId, @Path("message_id") String messageId, @Path("file_id") String fileId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/threads/{thread_id}/messages/{message_id}/files")
+    @GET("threads/{thread_id}/messages/{message_id}/files")
     Single<OpenAiResponse<MessageFile>> listMessageFiles(@Path("thread_id") String threadId, @Path("message_id") String messageId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/threads/{thread_id}/messages/{message_id}/files")
+    @GET("threads/{thread_id}/messages/{message_id}/files")
     Single<OpenAiResponse<MessageFile>> listMessageFiles(@Path("thread_id") String threadId, @Path("message_id") String messageId, @QueryMap Map<String, Object> filterRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/threads/{thread_id}/runs")
+    @POST("threads/{thread_id}/runs")
     Single<Run> createRun(@Path("thread_id") String threadId, @Body RunCreateRequest runCreateRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/threads/{thread_id}/runs/{run_id}")
+    @GET("threads/{thread_id}/runs/{run_id}")
     Single<Run> retrieveRun(@Path("thread_id") String threadId, @Path("run_id") String runId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/threads/{thread_id}/runs/{run_id}")
+    @POST("threads/{thread_id}/runs/{run_id}")
     Single<Run> modifyRun(@Path("thread_id") String threadId, @Path("run_id") String runId, @Body Map<String, String> metadata);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/threads/{thread_id}/runs")
+    @GET("threads/{thread_id}/runs")
     Single<OpenAiResponse<Run>> listRuns(@Path("thread_id") String threadId, @QueryMap Map<String, String> listSearchParameters);
 
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/threads/{thread_id}/runs/{run_id}/submit_tool_outputs")
+    @POST("threads/{thread_id}/runs/{run_id}/submit_tool_outputs")
     Single<Run> submitToolOutputs(@Path("thread_id") String threadId, @Path("run_id") String runId, @Body SubmitToolOutputsRequest submitToolOutputsRequest);
 
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/threads/{thread_id}/runs/{run_id}/cancel")
+    @POST("threads/{thread_id}/runs/{run_id}/cancel")
     Single<Run> cancelRun(@Path("thread_id") String threadId, @Path("run_id") String runId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/threads/runs")
+    @POST("threads/runs")
     Single<Run> createThreadAndRun(@Body CreateThreadAndRunRequest createThreadAndRunRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/threads/{thread_id}/runs/{run_id}/steps/{step_id}")
+    @GET("threads/{thread_id}/runs/{run_id}/steps/{step_id}")
     Single<RunStep> retrieveRunStep(@Path("thread_id") String threadId, @Path("run_id") String runId, @Path("step_id") String stepId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/threads/{thread_id}/runs/{run_id}/steps")
+    @GET("threads/{thread_id}/runs/{run_id}/steps")
     Single<OpenAiResponse<RunStep>> listRunSteps(@Path("thread_id") String threadId, @Path("run_id") String runId, @QueryMap Map<String, String> listSearchParameters);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/vector_stores")
+    @POST("vector_stores")
     Single<VectorStore> createVectorStore(@Body VectorStoreRequest request);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/vector_stores")
+    @GET("vector_stores")
     Single<OpenAiResponse<VectorStore>> listVectorStores(@QueryMap Map<String, Object> filterRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/vector_stores/{vector_store_id}")
+    @GET("vector_stores/{vector_store_id}")
     Single<VectorStore> retrieveVectorStore(@Path("vector_store_id") String vectorStoreId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/vector_stores/{vector_store_id}")
+    @POST("vector_stores/{vector_store_id}")
     Single<VectorStore> modifyVectorStore(@Path("vector_store_id") String vectorStoreId, @Body ModifyVectorStoreRequest request);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @DELETE("/vector_stores/{vector_store_id}")
+    @DELETE("vector_stores/{vector_store_id}")
     Single<DeleteResult> deleteVectorStore(@Path("vector_store_id") String vectorStoreId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/vector_stores/{vector_store_id}/files")
+    @POST("vector_stores/{vector_store_id}/files")
     Single<VectorStoreFile> createVectorStoreFile(@Path("vector_store_id") String vectorStoreId, @Body AssistantFileRequest fileRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/vector_stores/{vector_store_id}/files")
+    @GET("vector_stores/{vector_store_id}/files")
     Single<OpenAiResponse<VectorStoreFile>> listVectorStoreFiles(@Path("vector_store_id") String vectorStoreId, @QueryMap Map<String, Object> filterRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @DELETE("/vector_stores/{vector_store_id}/files/{file_id}")
+    @DELETE("vector_stores/{vector_store_id}/files/{file_id}")
     Single<DeleteResult> deleteVectorStoreFile(@Path("vector_store_id") String vectorStoreId, @Path("file_id") String fileId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/vector_stores/{vector_store_id}/file_batches")
+    @POST("vector_stores/{vector_store_id}/file_batches")
     Single<VectorStoreFilesBatch> createVectorStoreFileBatch(@Path("vector_store_id") String vectorStoreId, @Body VectorStoreFilesBatchRequest request);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/vector_stores/{vector_store_id}/file_batches/{batch_id}")
+    @GET("vector_stores/{vector_store_id}/file_batches/{batch_id}")
     Single<VectorStoreFilesBatch> retrieveVectorStoreFileBatch(@Path("vector_store_id") String vectorStoreId, @Path("batch_id") String batchId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel")
+    @POST("vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel")
     Single<VectorStoreFilesBatch> cancelVectorStoreFileBatch(@Path("vector_store_id") String vectorStoreId, @Path("batch_id") String batchId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/vector_stores/{vector_store_id}/file_batches/{batch_id}/files")
+    @GET("vector_stores/{vector_store_id}/file_batches/{batch_id}/files")
     Single<OpenAiResponse<VectorStoreFile>> listVectorStoreFilesInBatch(@Path("vector_store_id") String vectorStoreId, @Path("batch_id") String batchId, @QueryMap Map<String, Object> filterRequest);
 }

--- a/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
+++ b/client/src/main/java/com/theokanning/openai/client/OpenAiApi.java
@@ -50,92 +50,92 @@ import java.util.Map;
 
 public interface OpenAiApi {
 
-    @GET("v1/models")
+    @GET("/models")
     Single<OpenAiResponse<Model>> listModels();
 
-    @GET("/v1/models/{model_id}")
+    @GET("/models/{model_id}")
     Single<Model> getModel(@Path("model_id") String modelId);
 
-    @POST("/v1/completions")
+    @POST("/completions")
     Single<CompletionResult> createCompletion(@Body CompletionRequest request);
 
     @Streaming
-    @POST("/v1/completions")
+    @POST("/completions")
     Call<ResponseBody> createCompletionStream(@Body CompletionRequest request);
 
-    @POST("/v1/chat/completions")
+    @POST("/chat/completions")
     Single<ChatCompletionResult> createChatCompletion(@Body ChatCompletionRequest request);
 
     @Streaming
-    @POST("/v1/chat/completions")
+    @POST("/chat/completions")
     Call<ResponseBody> createChatCompletionStream(@Body ChatCompletionRequest request);
 
 
-    @POST("/v1/edits")
+    @POST("/edits")
     Single<EditResult> createEdit(@Body EditRequest request);
 
 
-    @POST("/v1/embeddings")
+    @POST("/embeddings")
     Single<EmbeddingResult> createEmbeddings(@Body EmbeddingRequest request);
 
 
-    @GET("/v1/files")
+    @GET("/files")
     Single<OpenAiResponse<File>> listFiles();
 
     @Multipart
-    @POST("/v1/files")
+    @POST("/files")
     Single<File> uploadFile(@Part("purpose") RequestBody purpose, @Part MultipartBody.Part file);
 
-    @DELETE("/v1/files/{file_id}")
+    @DELETE("/files/{file_id}")
     Single<DeleteResult> deleteFile(@Path("file_id") String fileId);
 
-    @GET("/v1/files/{file_id}")
+    @GET("/files/{file_id}")
     Single<File> retrieveFile(@Path("file_id") String fileId);
 
     @Streaming
-    @GET("/v1/files/{file_id}/content")
+    @GET("/files/{file_id}/content")
     Single<ResponseBody> retrieveFileContent(@Path("file_id") String fileId);
 
-    @POST("/v1/fine_tuning/jobs")
+    @POST("/fine_tuning/jobs")
     Single<FineTuningJob> createFineTuningJob(@Body FineTuningJobRequest request);
 
-    @GET("/v1/fine_tuning/jobs")
+    @GET("/fine_tuning/jobs")
     Single<OpenAiResponse<FineTuningJob>> listFineTuningJobs();
 
-    @GET("/v1/fine_tuning/jobs/{fine_tuning_job_id}")
+    @GET("/fine_tuning/jobs/{fine_tuning_job_id}")
     Single<FineTuningJob> retrieveFineTuningJob(@Path("fine_tuning_job_id") String fineTuningJobId);
 
-    @POST("/v1/fine_tuning/jobs/{fine_tuning_job_id}/cancel")
+    @POST("/fine_tuning/jobs/{fine_tuning_job_id}/cancel")
     Single<FineTuningJob> cancelFineTuningJob(@Path("fine_tuning_job_id") String fineTuningJobId);
 
-    @GET("/v1/fine_tuning/jobs/{fine_tuning_job_id}/events")
+    @GET("/fine_tuning/jobs/{fine_tuning_job_id}/events")
     Single<OpenAiResponse<FineTuningEvent>> listFineTuningJobEvents(@Path("fine_tuning_job_id") String fineTuningJobId);
 
-    @POST("/v1/completions")
+    @POST("/completions")
     Single<CompletionResult> createFineTuneCompletion(@Body CompletionRequest request);
 
-    @DELETE("/v1/models/{fine_tune_id}")
+    @DELETE("/models/{fine_tune_id}")
     Single<DeleteResult> deleteFineTune(@Path("fine_tune_id") String fineTuneId);
 
-    @POST("/v1/images/generations")
+    @POST("/images/generations")
     Single<ImageResult> createImage(@Body CreateImageRequest request);
 
-    @POST("/v1/images/edits")
+    @POST("/images/edits")
     Single<ImageResult> createImageEdit(@Body RequestBody requestBody);
 
-    @POST("/v1/images/variations")
+    @POST("/images/variations")
     Single<ImageResult> createImageVariation(@Body RequestBody requestBody);
 
-    @POST("/v1/audio/transcriptions")
+    @POST("/audio/transcriptions")
     Single<TranscriptionResult> createTranscription(@Body RequestBody requestBody);
 
-    @POST("/v1/audio/translations")
+    @POST("/audio/translations")
     Single<TranslationResult> createTranslation(@Body RequestBody requestBody);
 
-    @POST("/v1/audio/speech")
+    @POST("/audio/speech")
     Single<ResponseBody> createSpeech(@Body CreateSpeechRequest requestBody);
 
-    @POST("/v1/moderations")
+    @POST("/moderations")
     Single<ModerationResult> createModeration(@Body ModerationRequest request);
 
     /**
@@ -144,7 +144,7 @@ public interface OpenAiApi {
      * @return
      */
     @Deprecated
-    @GET("v1/dashboard/billing/subscription")
+    @GET("/dashboard/billing/subscription")
     Single<Subscription> subscription();
 
     /**
@@ -156,182 +156,182 @@ public interface OpenAiApi {
      * @return Consumption amount information.
      */
     @Deprecated
-    @GET("v1/dashboard/billing/usage")
+    @GET("/dashboard/billing/usage")
     Single<BillingUsage> billingUsage(@Query("start_date") LocalDate starDate, @Query("end_date") LocalDate endDate);
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/v1/assistants")
+    @POST("/assistants")
     Single<Assistant> createAssistant(@Body AssistantRequest request);
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/assistants")
+    @GET("/assistants")
     Single<OpenAiResponse<Assistant>> listAssistants(@QueryMap Map<String, Object> filterRequest);
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/assistants/{assistant_id}")
+    @GET("/assistants/{assistant_id}")
     Single<Assistant> retrieveAssistant(@Path("assistant_id") String assistantId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/v1/assistants/{assistant_id}")
+    @POST("/assistants/{assistant_id}")
     Single<Assistant> modifyAssistant(@Path("assistant_id") String assistantId, @Body ModifyAssistantRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @DELETE("/v1/assistants/{assistant_id}")
+    @DELETE("/assistants/{assistant_id}")
     Single<DeleteResult> deleteAssistant(@Path("assistant_id") String assistantId);
 
     //----
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/assistants/{assistant_id}/files/{file_id}")
+    @GET("/assistants/{assistant_id}/files/{file_id}")
     Single<AssistantFile> retrieveAssistantFile(@Path("assistant_id") String assistantId, @Path("file_id") String fileId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @DELETE("/v1/assistants/{assistant_id}/files/{file_id}")
+    @DELETE("/assistants/{assistant_id}/files/{file_id}")
     Single<DeleteResult> deleteAssistantFile(@Path("assistant_id") String assistantId, @Path("file_id") String fileId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/assistants/{assistant_id}/files")
+    @GET("/assistants/{assistant_id}/files")
     Single<OpenAiResponse<AssistantFile>> listAssistantFiles(@Path("assistant_id") String assistantId, @QueryMap Map<String, Object> filterRequest);
 
     //---
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/v1/threads")
+    @POST("/threads")
     Single<Thread> createThread(@Body ThreadRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/threads/{thread_id}")
+    @GET("/threads/{thread_id}")
     Single<Thread> retrieveThread(@Path("thread_id") String threadId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/v1/threads/{thread_id}")
+    @POST("/threads/{thread_id}")
     Single<Thread> modifyThread(@Path("thread_id") String threadId, @Body ThreadRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @DELETE("/v1/threads/{thread_id}")
+    @DELETE("/threads/{thread_id}")
     Single<DeleteResult> deleteThread(@Path("thread_id") String threadId);
 
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/v1/threads/{thread_id}/messages")
+    @POST("/threads/{thread_id}/messages")
     Single<Message> createMessage(@Path("thread_id") String threadId, @Body MessageRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/threads/{thread_id}/messages/{message_id}")
+    @GET("/threads/{thread_id}/messages/{message_id}")
     Single<Message> retrieveMessage(@Path("thread_id") String threadId, @Path("message_id") String messageId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @POST("/v1/threads/{thread_id}/messages/{message_id}")
+    @POST("/threads/{thread_id}/messages/{message_id}")
     Single<Message> modifyMessage(@Path("thread_id") String threadId, @Path("message_id") String messageId, @Body ModifyMessageRequest request);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/threads/{thread_id}/messages")
+    @GET("/threads/{thread_id}/messages")
     Single<OpenAiResponse<Message>> listMessages(@Path("thread_id") String threadId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/threads/{thread_id}/messages")
+    @GET("/threads/{thread_id}/messages")
     Single<OpenAiResponse<Message>> listMessages(@Path("thread_id") String threadId, @QueryMap Map<String, Object> filterRequest);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/threads/{thread_id}/messages/{message_id}/files/{file_id}")
+    @GET("/threads/{thread_id}/messages/{message_id}/files/{file_id}")
     Single<MessageFile> retrieveMessageFile(@Path("thread_id") String threadId, @Path("message_id") String messageId, @Path("file_id") String fileId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/threads/{thread_id}/messages/{message_id}/files")
+    @GET("/threads/{thread_id}/messages/{message_id}/files")
     Single<OpenAiResponse<MessageFile>> listMessageFiles(@Path("thread_id") String threadId, @Path("message_id") String messageId);
 
     @Headers({"OpenAI-Beta: assistants=v1"})
-    @GET("/v1/threads/{thread_id}/messages/{message_id}/files")
+    @GET("/threads/{thread_id}/messages/{message_id}/files")
     Single<OpenAiResponse<MessageFile>> listMessageFiles(@Path("thread_id") String threadId, @Path("message_id") String messageId, @QueryMap Map<String, Object> filterRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/threads/{thread_id}/runs")
+    @POST("/threads/{thread_id}/runs")
     Single<Run> createRun(@Path("thread_id") String threadId, @Body RunCreateRequest runCreateRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/threads/{thread_id}/runs/{run_id}")
+    @GET("/threads/{thread_id}/runs/{run_id}")
     Single<Run> retrieveRun(@Path("thread_id") String threadId, @Path("run_id") String runId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/threads/{thread_id}/runs/{run_id}")
+    @POST("/threads/{thread_id}/runs/{run_id}")
     Single<Run> modifyRun(@Path("thread_id") String threadId, @Path("run_id") String runId, @Body Map<String, String> metadata);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/threads/{thread_id}/runs")
+    @GET("/threads/{thread_id}/runs")
     Single<OpenAiResponse<Run>> listRuns(@Path("thread_id") String threadId, @QueryMap Map<String, String> listSearchParameters);
 
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/threads/{thread_id}/runs/{run_id}/submit_tool_outputs")
+    @POST("/threads/{thread_id}/runs/{run_id}/submit_tool_outputs")
     Single<Run> submitToolOutputs(@Path("thread_id") String threadId, @Path("run_id") String runId, @Body SubmitToolOutputsRequest submitToolOutputsRequest);
 
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/threads/{thread_id}/runs/{run_id}/cancel")
+    @POST("/threads/{thread_id}/runs/{run_id}/cancel")
     Single<Run> cancelRun(@Path("thread_id") String threadId, @Path("run_id") String runId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/threads/runs")
+    @POST("/threads/runs")
     Single<Run> createThreadAndRun(@Body CreateThreadAndRunRequest createThreadAndRunRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/threads/{thread_id}/runs/{run_id}/steps/{step_id}")
+    @GET("/threads/{thread_id}/runs/{run_id}/steps/{step_id}")
     Single<RunStep> retrieveRunStep(@Path("thread_id") String threadId, @Path("run_id") String runId, @Path("step_id") String stepId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/threads/{thread_id}/runs/{run_id}/steps")
+    @GET("/threads/{thread_id}/runs/{run_id}/steps")
     Single<OpenAiResponse<RunStep>> listRunSteps(@Path("thread_id") String threadId, @Path("run_id") String runId, @QueryMap Map<String, String> listSearchParameters);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/vector_stores")
+    @POST("/vector_stores")
     Single<VectorStore> createVectorStore(@Body VectorStoreRequest request);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/vector_stores")
+    @GET("/vector_stores")
     Single<OpenAiResponse<VectorStore>> listVectorStores(@QueryMap Map<String, Object> filterRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/vector_stores/{vector_store_id}")
+    @GET("/vector_stores/{vector_store_id}")
     Single<VectorStore> retrieveVectorStore(@Path("vector_store_id") String vectorStoreId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/vector_stores/{vector_store_id}")
+    @POST("/vector_stores/{vector_store_id}")
     Single<VectorStore> modifyVectorStore(@Path("vector_store_id") String vectorStoreId, @Body ModifyVectorStoreRequest request);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @DELETE("/v1/vector_stores/{vector_store_id}")
+    @DELETE("/vector_stores/{vector_store_id}")
     Single<DeleteResult> deleteVectorStore(@Path("vector_store_id") String vectorStoreId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/vector_stores/{vector_store_id}/files")
+    @POST("/vector_stores/{vector_store_id}/files")
     Single<VectorStoreFile> createVectorStoreFile(@Path("vector_store_id") String vectorStoreId, @Body AssistantFileRequest fileRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/vector_stores/{vector_store_id}/files")
+    @GET("/vector_stores/{vector_store_id}/files")
     Single<OpenAiResponse<VectorStoreFile>> listVectorStoreFiles(@Path("vector_store_id") String vectorStoreId, @QueryMap Map<String, Object> filterRequest);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @DELETE("/v1/vector_stores/{vector_store_id}/files/{file_id}")
+    @DELETE("/vector_stores/{vector_store_id}/files/{file_id}")
     Single<DeleteResult> deleteVectorStoreFile(@Path("vector_store_id") String vectorStoreId, @Path("file_id") String fileId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/vector_stores/{vector_store_id}/file_batches")
+    @POST("/vector_stores/{vector_store_id}/file_batches")
     Single<VectorStoreFilesBatch> createVectorStoreFileBatch(@Path("vector_store_id") String vectorStoreId, @Body VectorStoreFilesBatchRequest request);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/vector_stores/{vector_store_id}/file_batches/{batch_id}")
+    @GET("/vector_stores/{vector_store_id}/file_batches/{batch_id}")
     Single<VectorStoreFilesBatch> retrieveVectorStoreFileBatch(@Path("vector_store_id") String vectorStoreId, @Path("batch_id") String batchId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @POST("/v1/vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel")
+    @POST("/vector_stores/{vector_store_id}/file_batches/{batch_id}/cancel")
     Single<VectorStoreFilesBatch> cancelVectorStoreFileBatch(@Path("vector_store_id") String vectorStoreId, @Path("batch_id") String batchId);
 
     @Headers("OpenAI-Beta: assistants=v1")
-    @GET("/v1/vector_stores/{vector_store_id}/file_batches/{batch_id}/files")
+    @GET("/vector_stores/{vector_store_id}/file_batches/{batch_id}/files")
     Single<OpenAiResponse<VectorStoreFile>> listVectorStoreFilesInBatch(@Path("vector_store_id") String vectorStoreId, @Path("batch_id") String batchId, @QueryMap Map<String, Object> filterRequest);
 }

--- a/example/src/main/java/example/ServiceCreateExample.java
+++ b/example/src/main/java/example/ServiceCreateExample.java
@@ -17,11 +17,11 @@ import java.util.concurrent.TimeUnit;
  **/
 public class ServiceCreateExample {
 
-    private static final String BASE_URL = "https://api.openai.com/v1";
+    private static final String BASE_URL = "https://api.openai.com/v1/";
     private static final String API_KEY = "sk-1234567890";
 
     public static void main(String[] args) {
-        //1.使用默认的baseUrl,默认配置service,这里会默认先从环境变量中获取BaseURL(key:OPENAI_API_BASE_URL),如果没有则使用默认的"https://api.openai.com/v1";
+        //1.使用默认的baseUrl,默认配置service,这里会默认先从环境变量中获取BaseURL(key:OPENAI_API_BASE_URL),如果没有则使用默认的"https://api.openai.com/v1/";
         OpenAiService openAiService = new OpenAiService(API_KEY);
         //2. 使用自定义的baseUrl,默认配置配置service
         OpenAiService openAiService1 = new OpenAiService(API_KEY, BASE_URL);

--- a/example/src/main/java/example/ServiceCreateExample.java
+++ b/example/src/main/java/example/ServiceCreateExample.java
@@ -17,11 +17,11 @@ import java.util.concurrent.TimeUnit;
  **/
 public class ServiceCreateExample {
 
-    private static final String BASE_URL = "https://api.openai.com";
+    private static final String BASE_URL = "https://api.openai.com/v1";
     private static final String API_KEY = "sk-1234567890";
 
     public static void main(String[] args) {
-        //1.使用默认的baseUrl,默认配置service,这里会默认先从环境变量中获取BaseURL(key:OPENAI_API_BASE_URL),如果没有则使用默认的"https://api.openai.com/";
+        //1.使用默认的baseUrl,默认配置service,这里会默认先从环境变量中获取BaseURL(key:OPENAI_API_BASE_URL),如果没有则使用默认的"https://api.openai.com/v1";
         OpenAiService openAiService = new OpenAiService(API_KEY);
         //2. 使用自定义的baseUrl,默认配置配置service
         OpenAiService openAiService1 = new OpenAiService(API_KEY, BASE_URL);

--- a/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
+++ b/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeUnit;
 
 public class OpenAiService {
 
-    private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
+    private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1/";
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
     private static final ObjectMapper mapper = defaultObjectMapper();
 
@@ -93,7 +93,7 @@ public class OpenAiService {
      *
      * @param token   OpenAi token string "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
      * @param timeout http read timeout, Duration.ZERO means no timeout
-     * @param baseUrl OpenAi API base URL, default is "https://api.openai.com/v1"
+     * @param baseUrl OpenAi API base URL, default is "https://api.openai.com/v1/"
      */
     public OpenAiService(final String token, final Duration timeout, String baseUrl) {
         ObjectMapper mapper = defaultObjectMapper();

--- a/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
+++ b/service/src/main/java/com/theokanning/openai/service/OpenAiService.java
@@ -58,7 +58,7 @@ import java.util.concurrent.TimeUnit;
 
 public class OpenAiService {
 
-    private static final String DEFAULT_BASE_URL = "https://api.openai.com/";
+    private static final String DEFAULT_BASE_URL = "https://api.openai.com/v1";
     private static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(10);
     private static final ObjectMapper mapper = defaultObjectMapper();
 
@@ -93,7 +93,7 @@ public class OpenAiService {
      *
      * @param token   OpenAi token string "sk-XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
      * @param timeout http read timeout, Duration.ZERO means no timeout
-     * @param baseUrl OpenAi API base URL, default is "https://api.openai.com/"
+     * @param baseUrl OpenAi API base URL, default is "https://api.openai.com/v1"
      */
     public OpenAiService(final String token, final Duration timeout, String baseUrl) {
         ObjectMapper mapper = defaultObjectMapper();


### PR DESCRIPTION
This is also how it's done in basically all libraries, including OpenAI's official library
It's also required for sites like https://aimlapi.com. For example, when making a chat completion request, the URL needs to be https://api.aimlapi.com/chat/completions instead of https://api.aimlapi.com/v1/chat/completions.