### PR TITLE
新增 ChatMessageAccumulatorWrapper，以便于能够在使用chatCompletion时使用原始 chunk 数据…

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,14 +21,14 @@ OpenAi4J是一个非官方的Java库，旨在帮助java开发者与OpenAI的GPT�
 ## 导入依赖
 ### Gradle
 
-`implementation 'io.github.lambdua:<api|client|service>:0.22.3'`
+`implementation 'io.github.lambdua:<api|client|service>:0.22.4'`
 ### Maven
 ```xml
 
 <dependency>
     <groupId>io.github.lambdua</groupId>
     <artifactId>service</artifactId>
-    <version>0.22.3</version>
+    <version>0.22.4</version>
 </dependency>
 ```
 
@@ -61,7 +61,7 @@ static void simpleChat() {
 <dependency>
     <groupId>io.github.lambdua</groupId>
     <artifactId>api</artifactId>
-    <version>0.22.3</version>
+    <version>0.22.4</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ applications effortlessly.
 ## Import
 ### Gradle
 
-`implementation 'io.github.lambdua:<api|client|service>:0.22.3'`
+`implementation 'io.github.lambdua:<api|client|service>:0.22.4'`
 ### Maven
 ```xml
 
 <dependency>
   <groupId>io.github.lambdua</groupId>
   <artifactId>service</artifactId>
-    <version>0.22.3</version>
+    <version>0.22.4</version>
 </dependency>
 ```
 
@@ -67,7 +67,7 @@ To utilize pojos, import the api module:
 <dependency>
   <groupId>io.github.lambdua</groupId>
   <artifactId>api</artifactId>
-    <version>0.22.3</version>
+    <version>0.22.4</version>
 </dependency>
 ```
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lambdua</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.22.3</version>
+        <version>0.22.4</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>api</artifactId>

--- a/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionChunk.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/ChatCompletionChunk.java
@@ -1,5 +1,6 @@
 package com.theokanning.openai.completion.chat;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.theokanning.openai.Usage;
 import lombok.Data;
@@ -51,4 +52,13 @@ public class ChatCompletionChunk {
      */
     Usage usage;
 
+    /**
+     * The original data packet returned by chat completion.
+     * the value like this:
+     * <pre>
+     * data:{"id":"chatcmpl-A0QiHfuacgBSbvd8Ld1Por1HojY31","object":"chat.completion.chunk","created":1724666049,"model":"gpt-3.5-turbo-0125","system_fingerprint":null,"choices":[{"index":0,"delta":{"role":"assistant","content":"","refusal":null},"logprobs":null,"finish_reason":null}]}
+     * </pre>
+     */
+    @JsonIgnore
+    String source;
 }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lambdua</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.22.3</version>
+        <version>0.22.4</version>
     </parent>
     <packaging>jar</packaging>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.lambdua</groupId>
     <artifactId>example</artifactId>
-    <version>0.22.3</version>
+    <version>0.22.4</version>
     <name>example</name>
 
     <properties>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.lambdua</groupId>
             <artifactId>service</artifactId>
-            <version>0.22.3</version>
+            <version>0.22.4</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.lambdua</groupId>
     <artifactId>openai-java</artifactId>
-    <version>0.22.3</version>
+    <version>0.22.4</version>
     <packaging>pom</packaging>
     <description>openai java 版本</description>
     <url>https://github.com/Lambdua/openai-java</url>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lambdua</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.22.3</version>
+        <version>0.22.4</version>
     </parent>
     <packaging>jar</packaging>
 

--- a/service/src/main/java/com/theokanning/openai/service/ChatMessageAccumulatorWrapper.java
+++ b/service/src/main/java/com/theokanning/openai/service/ChatMessageAccumulatorWrapper.java
@@ -1,0 +1,28 @@
+package com.theokanning.openai.service;
+
+import com.theokanning.openai.completion.chat.ChatCompletionChunk;
+
+/**
+ * Wrapper class of ChatMessageAccumulator
+ *
+ * @author Allen Hu
+ * @date 2024/10/18
+ */
+public class ChatMessageAccumulatorWrapper {
+
+    private final ChatMessageAccumulator chatMessageAccumulator;
+    private final ChatCompletionChunk chatCompletionChunk;
+
+    public ChatMessageAccumulatorWrapper(ChatMessageAccumulator chatMessageAccumulator, ChatCompletionChunk chatCompletionChunk) {
+        this.chatMessageAccumulator = chatMessageAccumulator;
+        this.chatCompletionChunk = chatCompletionChunk;
+    }
+
+    public ChatMessageAccumulator getChatMessageAccumulator() {
+        return chatMessageAccumulator;
+    }
+
+    public ChatCompletionChunk getChatCompletionChunk() {
+        return chatCompletionChunk;
+    }
+}


### PR DESCRIPTION
新增 ChatMessageAccumulatorWrapper，以便于能够在使用chatCompletion时使用原始 chunk 数据。这一需求主要适用于chat API的转发场景。

```
Flowable<ChatCompletionChunk> streamedChatCompletion = openAiService.streamChatCompletion(requestBody);

AssistantMessage accumulatedMessage = openAiService.mapStreamToAccumulatorWrapper(streamedChatCompletion)
        .doOnNext((chatMessageAccumulatorWrapper -> {
            ChatMessageAccumulator chatMessageAccumulator = chatMessageAccumulatorWrapper.getChatMessageAccumulator();
            if (!chatMessageAccumulator.isFunctionCall()) {
                ChatCompletionChunk chatCompletionChunk = chatMessageAccumulatorWrapper.getChatCompletionChunk();
                String source = chatCompletionChunk.getSource();
                byte[] bytes = source.getBytes(StandardCharsets.UTF_8);
                if (null != bytes) {
                    sseEmitter.send(SseEmitter.event().data(bytes, MediaType.APPLICATION_JSON_UTF8));
                }
            }
        }))
        .doOnError(throwable -> {
            sseEmitter.completeWithError(throwable);
            log.error("streamChatCompletion error", throwable);
        })
        .lastElement()
        .blockingGet()
        .getChatMessageAccumulator()
        .getAccumulatedMessage();
```