### PR TITLE
Method to set the image processing quality

### DIFF
--- a/api/src/main/java/com/theokanning/openai/completion/chat/UserMessage.java
+++ b/api/src/main/java/com/theokanning/openai/completion/chat/UserMessage.java
@@ -7,8 +7,6 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.stream.Collectors;
@@ -57,6 +55,31 @@ public class UserMessage implements ChatMessage {
             }
         }
         return null;
+    }
+
+    /**
+     * Set the level of detail the images should be processed at.<br>
+     * This can either be {@code "high"} or {@code "low"}.
+     * 
+     * @param detailLevel the level of detail the images should be processed at
+     * @return com.theokanning.openai.completion.chat.UserMessage
+     * @author MightyElemental
+     * @see OpenAI: <a 
+     * href="https://platform.openai.com/docs/guides/vision#low-or-high-fidelity-image-understanding">
+     * Low or high fidelity image understanding</a>
+     * @date 2024/11/27
+     * */
+    @JsonIgnore
+    public UserMessage setImageDetail(String detailLevel) {
+        if (content == null || !(content instanceof Collection)) return this;
+        Collection<?> collection = (Collection<?>) content;
+        collection.stream().filter(item -> item instanceof ImageContent)
+                .filter(item -> ((ImageContent) item).getType().equals("image_url"))
+                .forEach(item -> {
+                    ImageUrl imgUrl = ((ImageContent) item).getImageUrl();
+                    imgUrl.setDetail(detailLevel);
+                });
+        return this;
     }
 
     /**

--- a/service/src/test/java/com/theokanning/openai/service/ChatCompletionTest.java
+++ b/service/src/test/java/com/theokanning/openai/service/ChatCompletionTest.java
@@ -664,6 +664,26 @@ class ChatCompletionTest {
         ChatCompletionChoice choice = service.createChatCompletion(chatCompletionRequest).getChoices().get(0);
         assertNotNull(choice.getMessage().getContent());
     }
+    
+    @Test
+    void setImageMessageDetail() {
+        final UserMessage imageMessage = UserMessage.buildImageMessage("What'\''s in this image?",
+                "https://upload.wikimedia.org/wikipedia/commons/thumb/d/dd/Gfp-wisconsin-madison-the-nature-boardwalk.jpg/2560px-Gfp-wisconsin-madison-the-nature-boardwalk.jpg");
+        
+        imageMessage.setImageDetail("high");
+        ((Collection<ImageContent>)imageMessage.getContent()).forEach(ic -> {
+            if (ic.getType().equals("image_url")) {
+                assertEquals("high", ic.getImageUrl().getDetail());
+            }
+        });
+        
+        imageMessage.setImageDetail("low");
+        ((Collection<ImageContent>)imageMessage.getContent()).forEach(ic -> {
+            if (ic.getType().equals("image_url")) {
+                assertEquals("low", ic.getImageUrl().getDetail());
+            }
+        });
+    }
 
     @Test
     void createInputAudioChatCompletion() throws URISyntaxException {


### PR DESCRIPTION
OpenAI vision can either use low res or high res. Low res is cheaper and uses only ``85 tokens``. High res uses ``85 tokens + 170 * tile_count``, where tile_count is the number of 512x512 tiles the image is split into. High res scales the image down so that the longest edge is <=2000px, and the short edge is <=768px.

To save on token cost or to improve quality, this change allows the users to choose processing quality.

https://platform.openai.com/docs/guides/vision#low-or-high-fidelity-image-understanding