### PR TITLE
Bump mbknor-jackson-jsonschema to 2.13

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -31,7 +31,7 @@
 
         <dependency>
             <groupId>com.kjetland</groupId>
-            <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
+            <artifactId>mbknor-jackson-jsonschema_2.13</artifactId>
             <version>1.0.39</version>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Bumping `mbknor-jackson-jsonschema` to `2.13`.

---

But, to expand on the issue:

Dependency in case:
```
<dependency>
    <groupId>com.kjetland</groupId>
    <artifactId>mbknor-jackson-jsonschema_2.12</artifactId>
    <version>1.0.39</version>
    <exclusions>
        <exclusion>
            <artifactId>jackson-databind</artifactId>
            <groupId>com.fasterxml.jackson.core</groupId>
        </exclusion>
    </exclusions>
</dependency>
```

---

As far I could see, this dependency is used to generate a json schema when using "advanced options" such as function calls.

For example, when using this together with Quarkus, it breaks because the dependency is build for Scala up to 2.13.
> Implemented in Scala (Built for 2.10, 2.11, 2.12 and 2.13)

When running this with current dependency (`v 2.12`) it breaks and need to be removed and `2.13` added manually.
But, to make it worse, the dependency is quite old and probably not maintained anymore: last release was done more than 4y ago.

`openai-java`, the official SDK for OpenAI was also released recently and they don't use this dependency.
It might be worth [checking their code](https://github.com/openai/openai-java/blob/main/openai-java-core/src/main/kotlin/com/openai/models/ResponseFormatJsonSchema.kt#L46) and understanding how they have done it and improve this lib with that.