### PR TITLE
Add support for capturing usage prompt_tokens_details and completion_tokens_details

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -21,14 +21,14 @@ OpenAi4J是一个非官方的Java库，旨在帮助java开发者与OpenAI的GPT�
 ## 导入依赖
 ### Gradle
 
-`implementation 'io.github.lambdua:<api|client|service>:0.22.91'`
+`implementation 'io.github.lambdua:<api|client|service>:0.22.92'`
 ### Maven
 ```xml
 
 <dependency>
     <groupId>io.github.lambdua</groupId>
     <artifactId>service</artifactId>
-    <version>0.22.91</version>
+    <version>0.22.92</version>
 </dependency>
 ```
 
@@ -61,7 +61,7 @@ static void simpleChat() {
 <dependency>
     <groupId>io.github.lambdua</groupId>
     <artifactId>api</artifactId>
-    <version>0.22.91</version>
+    <version>0.22.92</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ applications effortlessly.
 ## Import
 ### Gradle
 
-`implementation 'io.github.lambdua:<api|client|service>:0.22.91'`
+`implementation 'io.github.lambdua:<api|client|service>:0.22.92'`
 ### Maven
 ```xml
 
 <dependency>
   <groupId>io.github.lambdua</groupId>
   <artifactId>service</artifactId>
-    <version>0.22.91</version>
+    <version>0.22.92</version>
 </dependency>
 ```
 
@@ -67,7 +67,7 @@ To utilize pojos, import the api module:
 <dependency>
   <groupId>io.github.lambdua</groupId>
   <artifactId>api</artifactId>
-    <version>0.22.91</version>
+    <version>0.22.92</version>
 </dependency>
 ```
 

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lambdua</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.22.91</version>
+        <version>0.22.92</version>
     </parent>
     <packaging>jar</packaging>
     <artifactId>api</artifactId>

--- a/api/src/main/java/com/theokanning/openai/CompletionTokensDetails.java
+++ b/api/src/main/java/com/theokanning/openai/CompletionTokensDetails.java
@@ -1,0 +1,23 @@
+package com.theokanning.openai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * Breakdown of tokens used in a completion.
+ */
+@Data
+public class CompletionTokensDetails {
+
+    @JsonProperty("reasoning_tokens")
+    long reasoningTokens;
+
+    @JsonProperty("audio_tokens")
+    long audioTokens;
+
+    @JsonProperty("accepted_prediction_tokens")
+    long acceptedPredictionTokens;
+
+    @JsonProperty("rejected_prediction_tokens")
+    long rejectedPredictionTokens;
+}

--- a/api/src/main/java/com/theokanning/openai/PromptTokensDetails.java
+++ b/api/src/main/java/com/theokanning/openai/PromptTokensDetails.java
@@ -1,0 +1,22 @@
+package com.theokanning.openai;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+/**
+ * Breakdown of tokens used in the prompt.
+ */
+@Data
+public class PromptTokensDetails {
+    /**
+     * Cached tokens present in the prompt.
+     */
+    @JsonProperty("cached_tokens")
+    long cachedTokens;
+
+    /**
+     * Audio input tokens present in the prompt.
+     */
+    @JsonProperty("audio_tokens")
+    long audioTokens;
+}

--- a/api/src/main/java/com/theokanning/openai/Usage.java
+++ b/api/src/main/java/com/theokanning/openai/Usage.java
@@ -25,4 +25,16 @@ public class Usage {
      */
     @JsonProperty("total_tokens")
     long totalTokens;
+
+    /**
+     * Breakdown of tokens used in the prompt.
+     */
+    @JsonProperty("prompt_tokens_details")
+    PromptTokensDetails promptTokensDetails;
+
+    /**
+     * Breakdown of tokens used in a completion.
+     */
+    @JsonProperty("completion_tokens_details")
+    CompletionTokensDetails completionTokensDetails;
 }

--- a/api/src/test/resources/fixtures/ChatCompletionResult.json
+++ b/api/src/test/resources/fixtures/ChatCompletionResult.json
@@ -315,6 +315,14 @@
   "usage": {
     "prompt_tokens": 9,
     "completion_tokens": 12,
-    "total_tokens": 21
+    "total_tokens": 21,
+    "prompt_tokens_details": {
+      "cached_tokens": 0
+    },
+    "completion_tokens_details": {
+      "reasoning_tokens": 0,
+      "accepted_prediction_tokens": 0,
+      "rejected_prediction_tokens": 0
+    }
   }
 }

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lambdua</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.22.91</version>
+        <version>0.22.92</version>
     </parent>
     <packaging>jar</packaging>
 

--- a/example/pom.xml
+++ b/example/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.github.lambdua</groupId>
     <artifactId>example</artifactId>
-    <version>0.22.91</version>
+    <version>0.22.92</version>
     <name>example</name>
 
     <properties>
@@ -17,7 +17,7 @@
         <dependency>
             <groupId>io.github.lambdua</groupId>
             <artifactId>service</artifactId>
-            <version>0.22.91</version>
+            <version>0.22.92</version>
         </dependency>
 
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>io.github.lambdua</groupId>
     <artifactId>openai-java</artifactId>
-    <version>0.22.91</version>
+    <version>0.22.92</version>
     <packaging>pom</packaging>
     <description>openai java 版本</description>
     <url>https://github.com/Lambdua/openai-java</url>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>io.github.lambdua</groupId>
         <artifactId>openai-java</artifactId>
-        <version>0.22.91</version>
+        <version>0.22.92</version>
     </parent>
     <packaging>jar</packaging>
 

--- a/service/src/test/java/com/theokanning/openai/service/ChatCompletionTest.java
+++ b/service/src/test/java/com/theokanning/openai/service/ChatCompletionTest.java
@@ -43,8 +43,11 @@ class ChatCompletionTest {
                 .logitBias(new HashMap<>())
                 .build();
 
-        List<ChatCompletionChoice> choices = service.createChatCompletion(chatCompletionRequest).getChoices();
-        assertEquals(5, choices.size());
+        ChatCompletionResult chatCompletionResult = service.createChatCompletion(chatCompletionRequest);
+        assertEquals(5, chatCompletionResult.getChoices().size());
+        assertNotNull(chatCompletionResult.getUsage());
+        assertNotNull(chatCompletionResult.getUsage().getPromptTokensDetails());
+        assertNotNull(chatCompletionResult.getUsage().getCompletionTokensDetails());
     }
 
     @Test


### PR DESCRIPTION
The existing code does not capture `prompt_tokens_details` and `completion_tokens_details` usage objects. For example, `prompt_tokens_details` contains the `cached_tokens` attribute, which can be useful in understanding how much input prompts are cached (related doc [here](https://platform.openai.com/docs/guides/prompt-caching) ). This PR adds `PromptTokensDetails` and `PromptTokensDetails` attributes to the existing `Usage` class. I expect this change to be backward-compatible.

Related API reference [here](https://platform.openai.com/docs/api-reference/chat/object)